### PR TITLE
MAINT: update for 2.3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # install bilby directly from source to support plugins
-        python -m pip install --pre bilby==2.3.0rc0 "numpy<2"
         python -m pip install .[test]
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # install bilby directly from source to support plugins
-        python -m pip install git+https://git.ligo.org/lscsoft/bilby.git
+        python -m pip install --pre bilby==2.3.0rc0
         python -m pip install .[test]
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # install bilby directly from source to support plugins
-        python -m pip install --pre bilby==2.3.0rc0
+        python -m pip install --pre bilby==2.3.0rc0 "numpy<2"
         python -m pip install .[test]
     - name: Test with pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "bilby",
+    "bilby>=2.3.0",
     "numpy",
 ]
 

--- a/src/demo_sampler_bilby/plugin.py
+++ b/src/demo_sampler_bilby/plugin.py
@@ -114,12 +114,16 @@ class DemoSampler(NestedSampler):
         filenames = []
         dirs = []
 
-        # The following lines return the defaults, an empty list for filenames
-        # and <outdir>/<sampler_name>_<label> for the directories. If
-        # `abbreviation` has been specified, it will be used instead of
-        # `<sampler_name>. Uncomment these lines to use these defaults and
-        # add additional files/directories or remove the method entirely if
-        # the default are enough.
+        # If this method is not defined the defaults are used; an empty list
+        # for filenames and <outdir>/<sampler_name>_<label> for the
+        # directories. If `abbreviation` has been specified, it will be used
+        # instead of `<sampler_name>.
+        # Delete this method to use the defaults.
+
+        # Alternatively, if your sampler uses the defaults plus additional
+        # files and/or directories. Uncomment the following lines and add any
+        # additional files to the relevant lists.
+        # Note: the class here should match the parent class.
         # filenames, dirs = super(NestedSampler, cls).get_expected_outputs(
         #     outdir=outdir, label=label
         # )

--- a/src/demo_sampler_bilby/plugin.py
+++ b/src/demo_sampler_bilby/plugin.py
@@ -109,12 +109,17 @@ class DemoSampler(NestedSampler):
         """
         # Update this function to list any files and/or directories produced by
         # the sampler when it runs.
+
+        # If no files/directories are produced, both lists should be empty.
         filenames = []
         dirs = []
+
         # The following lines return the defaults, an empty list for filenames
         # and <outdir>/<sampler_name>_<label> for the directories. If
         # `abbreviation` has been specified, it will be used instead of
-        # `<sampler_name>. Uncomment these lines to use this default
+        # `<sampler_name>. Uncomment these lines to use these defaults and
+        # add additional files/directories or remove the method entirely if
+        # the default are enough.
         # filenames, dirs = super(NestedSampler, cls).get_expected_outputs(
         #     outdir=outdir, label=label
         # )

--- a/src/demo_sampler_bilby/plugin.py
+++ b/src/demo_sampler_bilby/plugin.py
@@ -13,6 +13,16 @@ class DemoSampler(NestedSampler):
     This class should inherit from :code:`MCMCSampler` or :code:`NestedSampler`
     """
 
+    sampler_name = "demo_sampler"
+    """
+    Name of the sampler. This should match the name specified in the entry
+    point.
+    """
+    abbreviation = None
+    """
+    Abbreviation for the sampler name. Does not have to be specified.
+    """
+
     @property
     def external_sampler_name(self) -> str:
         """The name of package that provides the sampler."""
@@ -75,3 +85,37 @@ class DemoSampler(NestedSampler):
 
         # Must return the result object
         return self.result
+
+    @classmethod
+    def get_expected_outputs(cls, outdir=None, label=None):
+        """Get lists of the expected outputs directories and files.
+
+        These are used by :code:`bilby_pipe` when transferring files via
+        HTCondor. Both can be empty.
+
+        Parameters
+        ----------
+        outdir : str
+            The output directory.
+        label : str
+            The label for the run.
+
+        Returns
+        -------
+        list
+            List of file names.
+        list
+            List of directory names.
+        """
+        # Update this function to list any files and/or directories produced by
+        # the sampler when it runs.
+        filenames = []
+        dirs = []
+        # The following lines return the defaults, an empty list for filenames
+        # and <outdir>/<sampler_name>_<label> for the directories. If
+        # `abbreviation` has been specified, it will be used instead of
+        # `<sampler_name>. Uncomment these lines to use this default
+        # filenames, dirs = super(NestedSampler, cls).get_expected_outputs(
+        #     outdir=outdir, label=label
+        # )
+        return filenames, dirs

--- a/tests/test_bilby_integration.py
+++ b/tests/test_bilby_integration.py
@@ -1,4 +1,5 @@
 import bilby
+from demo_sampler_bilby.plugin import DemoSampler
 import numpy as np
 import pytest
 
@@ -44,3 +45,12 @@ def test_run_sampler(bilby_likelihood, bilby_priors, tmp_path, sampler_kwargs):
         sampler="demo_sampler",    # This should match the name of the sampler
         outdir=outdir,
     )
+
+
+def test_expected_outputs():
+    filenames, dirs = DemoSampler.get_expected_outputs(
+        outdir="outdir",
+        label="test",
+    )
+    assert len(filenames) == 0
+    assert len(dirs) == 0


### PR DESCRIPTION
Update the template to use bilby 2.3.0rc0.

I've added `sampler_name`, `abbreviation` and `get_expected_outputs` to the template since these are new since the last template.